### PR TITLE
Add support for scoped package installation.

### DIFF
--- a/dukpy/install.py
+++ b/dukpy/install.py
@@ -13,8 +13,10 @@ from .evaljs import evaljs
 
 try:
     from urllib.request import urlopen
+    from urllib.parse import quote_plus
 except ImportError:
     from urllib2 import urlopen
+    from urllib import quote_plus
 
 
 def main():
@@ -99,7 +101,7 @@ def _fetch_package_info(package_name):
 
 
 def _resolve_dependencies(package_name, version):
-    package_info = _fetch_package_info(package_name)
+    package_info = _fetch_package_info(quote_plus(package_name, safe='@'))
     package_versions = package_info['versions']
     matching_version = _resolve_version(version, package_versions)
     version_info = package_versions.get(matching_version)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -54,6 +54,11 @@ class TestPackageInstaller(object):
             dukpy_install.main()
         assert os.path.exists(os.path.join('./js_modules', 'react'))
 
+    def test_install_scoped_package(self):
+        with mock.patch.object(sys, 'argv', ['dukpy-install', '@reactivex/rxjs', '5.0.0-beta.11']):
+            dukpy_install.main()
+        assert os.path.exists(os.path.join('./js_modules', '@reactivex', 'rxjs'))
+
     def test_install_command_substrate_error(self):
         with mock.patch.object(sys, 'argv', ['dukpy-install', 'react', '9999',
                                              '-d', self.tmpdir]):


### PR DESCRIPTION
When getting info from [http://registry.npmjs.org](http://registry.npmjs.org), the information retrieval will fail for scoped packages, if the slash is not encoded to %2f.

This PR will just quote the package name, leaving the @ intact, when searching for the information.