### PR TITLE
Add jscore to MANIFEST.in and setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include src *.h
+recursive-include dukpy/jscore *.js
 recursive-include dukpy/jsmodules *.js

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     ext_modules=[duktape],
     install_requires=INSTALL_REQUIRES,
     package_data={
-        'dukpy': ['jsmodules/*.js', 'jsmodules/react/*.js',
+        'dukpy': ['jscore/*.js', 'jsmodules/*.js', 'jsmodules/react/*.js',
                   'jsmodules/less/*/*.js', 'jsmodules/less/*/*/*.js'],
     },
     classifiers=[


### PR DESCRIPTION
Without this, `less_compile` won't work when dukpy is installed with setup.py (or pip for that matter) since the `path` module is missing.