### PR TITLE
Include license and test files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
 recursive-include src *.h
 recursive-include dukpy/jscore *.js
 recursive-include dukpy/jsmodules *.js
+recursive-include tests *
+
+include LICENSE


### PR DESCRIPTION
The MIT license requires license files be included in all copies of the program.  The tests are often used by downstream packagers to make sure their builds are correct.