### PR TITLE
Include tests in sdist tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include src *.h
 recursive-include dukpy/jscore *.js
 recursive-include dukpy/jsmodules *.js
+recursive-include tests *
 include LICENSE


### PR DESCRIPTION
This allows distributors to execute tests against their python stack to see if basically the dukpy works.