### PR TITLE
Fix a ResourceWarning: unclosed file in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ py_version = sys.version_info[:2]
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 try:
-    README = open(os.path.join(HERE, 'README.rst')).read()
+    with open(os.path.join(HERE, 'README.rst')) as fh:
+        README = fh.read()
 except IOError:
     README = ''
 


### PR DESCRIPTION
Hello,

Here is a small patch to fix that warning:
```python
  /private/var/folders/b6/t8dzh1094157tl2364wnb1jh0000gn/T/pip-install-rxxe801_/dukpy/setup.py:10: ResourceWarning: unclosed file <_io.TextIOWrapper name='/private/var/folders/b6/t8dzh1094157tl2364wnb1jh0000gn/T/pip-install-rxxe801_/dukpy/README.rst' mode='r' encoding='UTF-8'>
    README = open(os.path.join(HERE, 'README.rst')).read()
  ResourceWarning: Enable tracemalloc to get the object allocation traceback
```