### PR TITLE
Fix get-pip url for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ env:
   - ls -lh "${PYTHON_INSTALL_EXE}"
   - stat "${PYTHON_INSTALL_EXE}"
   - /Applications/Python\ ${PYTHON_VERSION_SHORT}/Install\ Certificates.command || echo "No need to fix certificates"
-  - if [ "2.7" = "$PYTHON_VERSION" ]; then curl https://bootstrap.pypa.io/2.7/get-pip.py | ${PYTHON_INSTALL_EXE}; else curl https://bootstrap.pypa.io/get-pip.py | ${PYTHON_INSTALL_EXE}; fi
+  - if [ "2.7" = "$PYTHON_VERSION" ]; then curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | ${PYTHON_INSTALL_EXE}; else curl https://bootstrap.pypa.io/get-pip.py | ${PYTHON_INSTALL_EXE}; fi
   - >
     "${PYTHON_INSTALL_EXE}" -m pip install -U pip
   - >
@@ -116,7 +116,7 @@ env:
   - >
     "${PYTHON_INSTALL_EXE}" -m virtualenv "${PYTHON_VENV_PATH}"
   - . "${PYTHON_VENV_PATH}/bin/activate"
-  - if [ "2.7" = "$PYTHON_VERSION" ]; then curl https://bootstrap.pypa.io/2.7/get-pip.py | python; else curl https://bootstrap.pypa.io/get-pip.py | python; fi
+  - if [ "2.7" = "$PYTHON_VERSION" ]; then curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python; else curl https://bootstrap.pypa.io/get-pip.py | python; fi
   - python --version
   - pip --version
 


### PR DESCRIPTION
I am not sure how I ended up here but I saw a travis failure and it seems the url for get-pip for python 2.7 has changed. As you can see on the message:
```
$ if [ "2.7" = "$PYTHON_VERSION" ]; then curl https://bootstrap.pypa.io/2.7/get-pip.py | ${PYTHON_INSTALL_EXE}; else curl https://bootstrap.pypa.io/get-pip.py | ${PYTHON_INSTALL_EXE}; fi

Hi there!

The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/2.7/get-pip.py

Sorry if this change causes any inconvenience for you!
We don't have a good mechanism to make more gradual changes here, and this
renaming is a part of an effort to make it easier to us to update these
scripts, when there's a pip release. It's also essential for improving how we
handle the `get-pip.py` scripts, when pip drops support for a Python minor
version.
There are no more renames/URL changes planned, and we don't expect that a need
would arise to do this again in the near future.
Thanks for understanding!
- Pradyun, on behalf of the volunteers who maintain pip.
```