### PR TITLE
Print a nicer error message when a Python function is not found

### DIFF
--- a/dukpy/evaljs.py
+++ b/dukpy/evaljs.py
@@ -69,6 +69,10 @@ class JSInterpreter(object):
         """
         self._funcs[name] = func
 
+    def _check_exported_function_exists(self, func):
+        func = func.decode('utf-8')
+        return func in self._funcs
+
     def _call_python(self, func, json_args):
         # Arguments came in reverse order from JS
         func = func.decode('utf-8')

--- a/src/_support.c
+++ b/src/_support.c
@@ -73,6 +73,15 @@ int call_py_function(duk_context *ctx) {
     duk_pop(ctx);
     duk_pop(ctx);
 
+    ret = PyObject_CallMethod(interpreter, "_check_exported_function_exists",
+                              CONDITIONAL_PY3("y", "s"), pyfuncname);
+
+    if (ret == Py_False) {
+        duk_push_error_object(ctx, DUK_ERR_REFERENCE_ERROR,
+                              "No Python Function named %s", pyfuncname);
+        duk_throw(ctx);
+    }
+
     ret = PyObject_CallMethod(interpreter, "_call_python", CONDITIONAL_PY3("yy", "ss"),
                               pyfuncname, args);
 


### PR DESCRIPTION
Right now if you pass `call_python` the wrong function name, you get a pretty strange error message (which is a kind of mangled version of an underlying `KeyError`). This PR makes the error nicer and also changes it to a JS `ReferenceError`, which seems more appropriate.