### PR TITLE
Build wheels for linux-aarch64

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -24,10 +24,17 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.16.5
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_LINUX: "auto aarch64"
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This is needed to run dukpy on, say, a Raspberry Pi.

See example issue in https://github.com/dknowles2/ha-pitboss/issues/42

Based on directions in https://cibuildwheel.pypa.io/en/stable/faq/#emulation this also needs to set up QEMU for the Linux runner to enable cross-compiles via emulation.