### PR TITLE
fix: prevent crash with unicode emoji (e.g. 🏠)

### DIFF
--- a/dukpy/evaljs.py
+++ b/dukpy/evaljs.py
@@ -45,7 +45,7 @@ class JSInterpreter(object):
 
         Returns the last object on javascript stack.
         """
-        jsvars = json.dumps(kwargs)
+        jsvars = json.dumps(kwargs, ensure_ascii=False)
         jscode = self._adapt_code(code)
 
         if not isinstance(jscode, bytes):

--- a/tests/test_evaljs.py
+++ b/tests/test_evaljs.py
@@ -30,8 +30,11 @@ class TestEvalJS(unittest.TestCase):
         assert s == '華華'
 
     def test_unicode_emoji(self):
-        s = dukpy.evaljs("dukpy.c + 'B'", c="🏠")
-        assert s == '🏠B'
+        s1 = dukpy.evaljs("dukpy.c + 'B'", c="🏠")
+        assert s1 == '🏠B'
+
+        s2 = dukpy.evaljs("dukpy.c + 'C'", c="👍🏾")
+        assert s2 == '👍🏾C'
 
     def test_eval_files(self):
         testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'test.js')

--- a/tests/test_evaljs.py
+++ b/tests/test_evaljs.py
@@ -29,6 +29,10 @@ class TestEvalJS(unittest.TestCase):
         s = dukpy.evaljs("dukpy.c + '華'", c="華")
         assert s == '華華'
 
+    def test_unicode_emoji(self):
+        s = dukpy.evaljs("dukpy.c + 'B'", c="🏠")
+        assert s == '🏠B'
+
     def test_eval_files(self):
         testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'test.js')
         with open(testfile) as f:


### PR DESCRIPTION
Should fix #75 

I ran pytest and all tests still pass. I also added an additional test which uses unicode emoji.